### PR TITLE
fix query parse with no position increment

### DIFF
--- a/src/core/queryparser/QueryParser.cpp
+++ b/src/core/queryparser/QueryParser.cpp
@@ -368,7 +368,7 @@ QueryPtr QueryParser::getFieldQuery(const String& field, const String& queryText
         return newTermQuery(newLucene<Term>(field, term));
     } else {
         if (severalTokensAtSamePosition) {
-            if (positionCount == 1) {
+            if (positionCount <= 1) {
                 // no phrase query
                 BooleanQueryPtr q(newBooleanQuery(true));
                 for (int32_t i = 0; i < numTokens; ++i) {


### PR DESCRIPTION
It is possible to generate a token stream with multiple tokens but no position increments.  In this case, `positionCount` will be 0, and this check will fail causing the query to be incorrectly interpreted as a phrase.  With this change, the `positionCount==0` case will be interpreted as an unordered collection of terms (`BooleanQuery` of `SHOULD` clauses) rather than as a phrase (`MultiPhraseQuery`).