### PR TITLE
don't retain input file handles

### DIFF
--- a/src/core/include/_SimpleFSDirectory.h
+++ b/src/core/include/_SimpleFSDirectory.h
@@ -24,7 +24,7 @@ public:
     static const int32_t FILE_ERROR;
 
 protected:
-    ifstreamPtr file;
+    String path;
     int64_t position;
     int64_t length;
 


### PR DESCRIPTION
- Don't retain input file handles in the IndexReader between reads.  This can lead to file handle exhaustion for highly segmented indices.
- Throw immediately on failure to open or write to an output file. 